### PR TITLE
Ensure large strings detected to be UTF-8 are always valid-encoded

### DIFF
--- a/lib/hippie_csv/support.rb
+++ b/lib/hippie_csv/support.rb
@@ -9,18 +9,7 @@ module HippieCSV
       end
 
       def encode(string)
-        unless string.valid_encoding?
-          string = begin
-            current_encoding = detect_encoding(string)
-            if !current_encoding.nil?
-              string.encode(ENCODING, current_encoding)
-            else
-              magical_encode(string)
-            end
-          rescue Encoding::InvalidByteSequenceError
-            magical_encode(string)
-          end
-        end
+        string = ensure_valid_encoding(string)
 
         DELIMETERS.each do |delimiter|
           string.gsub!(blank_line_regex(delimiter), "")
@@ -70,6 +59,20 @@ module HippieCSV
       end
 
       private
+
+      def ensure_valid_encoding(string)
+        return string if string.valid_encoding?
+
+        current_encoding = detect_encoding(string)
+
+        if !current_encoding.nil? && current_encoding != ENCODING
+          string.encode(ENCODING, current_encoding)
+        else
+          magical_encode(string)
+        end
+      rescue Encoding::InvalidByteSequenceError
+        magical_encode(string)
+      end
 
       def blank_line_regex(delimiter)
         /^#{delimiter}+(\r\n|\r)$/

--- a/spec/hippie_csv/support_spec.rb
+++ b/spec/hippie_csv/support_spec.rb
@@ -38,6 +38,17 @@ describe HippieCSV::Support do
       end
     end
 
+    context "with a string detected to be UTF-8 but with an invalid byte sequence" do
+      let(:utf8_string) { ("Rubyのメ" * HippieCSV::ENCODING_SAMPLE_CHARACTER_COUNT).force_encoding("utf-8") }
+      let(:string) { utf8_string << "\xBF"}
+
+      it "ensures encoding becomes valid" do
+        expect(string).not_to be_valid_encoding
+
+        expect(subject.encode(string)).to be_valid_encoding
+      end
+    end
+
     context 'with unquoted fields and \r or \n' do
       let(:string) { "id,first_name,last_name\r123,Heinrich,Schütz\r\n" }
 


### PR DESCRIPTION
When we try to parse very large CSV's, we only detect the encoding up to the first 10,000 characters. 

This is an issue for CSV's where the first 10,000 characters may be valid UTF-8 characters but then contain an invalid byte mark further down the body. For such CSV's, we don't end up encoding the invalid byte marks to be valid UTF-8 characters.

This PR ensures that strings detected to be `UTF-8` are valid encoded.