### PR TITLE
Updating streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,22 @@ Or install it yourself as:
 
 ## Usage
 
-Exposes two public methods: `read` (for paths to files), and `parse` (for
-strings).
+Exposes three public methods:
+1. `.read` a file path to an array. Reads from the file all at once, building the whole CSV object in memory.
+2. `.parse` an in memory string to an array.
+3. `.stream` from a file path and parse line by line, calling a given block on each row.
+
+**Note**: Processing large files using read or parse is a memory intensive operation. Use stream for parsing a CSV file line by line from the file to save memory. This method will use less memory but take longer, as we run each line through parse.
+
 
 ```ruby
 require 'hippie_csv'
 
 HippieCSV.read("path/to/data.csv")
+
+HippieCSV.stream("path/to/data.csv") do |row|
+  # use row here...
+end
 
 HippieCSV.parse(csv_string)
 ```

--- a/lib/hippie_csv.rb
+++ b/lib/hippie_csv.rb
@@ -9,12 +9,10 @@ module HippieCSV
   end
 
   def self.parse(string)
-    string = Support.encode(string)
     Support.maybe_parse(string) || (raise UnableToParseError)
   end
 
-  def self.stream(path, string)
-    string = Support.encode(string)
-    Support.maybe_stream(path, string) || (raise UnableToParseError)
+  def self.stream(path, &block)
+    Support.maybe_stream(path, &block)
   end
 end

--- a/spec/fixtures/small_file.csv
+++ b/spec/fixtures/small_file.csv
@@ -1,0 +1,2 @@
+name,email
+stephen,test@example.com

--- a/spec/hippie_csv/support_spec.rb
+++ b/spec/hippie_csv/support_spec.rb
@@ -68,8 +68,23 @@ describe HippieCSV::Support do
   end
 
   describe ".maybe_parse" do
-    it "needs to be written" do
-      skip # TODO write this test
+    let(:file_path) { fixture_path(:small_file) }
+    it "works" do
+      expect(subject.maybe_parse(subject.file_path_to_string(file_path))).to eq(
+        [["name", "email"], ["stephen", "test@example.com"]]
+      )
+    end
+  end
+
+  describe ".maybe_stream" do
+    let(:file_path) { fixture_path(:small_file) }
+    it "works" do
+      result = []
+      subject.maybe_stream(file_path) { |row| result << row }
+
+      expect(result).to eq(
+        [["name", "email"], ["stephen", "test@example.com"]]
+      )
     end
   end
 
@@ -82,19 +97,6 @@ describe HippieCSV::Support do
 
       expect(subject.parse_csv(string, quote_character)).to eq(
         [["name", "email"], ["stephen", "test@example.com"]]
-      )
-    end
-  end
-
-  describe ".stream_csv" do
-    let(:string) { "name,email\nstephen,test@example.com"}
-    let(:quote_character) { "\"" }
-    let(:file_path) { fixture_path(:normal) }
-
-    it "works" do
-      expect(subject).to receive(:guess_delimeter).with(subject.file_path_to_string(file_path), quote_character).and_return(',')
-      expect(subject.stream_csv(file_path, subject.file_path_to_string(file_path), quote_character)[0]).to eq(
-        ["id", "email", "name", "country", "city", "created_at", "admin"]
       )
     end
   end

--- a/spec/hippie_csv_spec.rb
+++ b/spec/hippie_csv_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require "csv"
 
 describe HippieCSV do
+
   let(:string) { "test" }
 
   describe ".read" do
@@ -16,13 +17,6 @@ describe HippieCSV do
   end
 
   describe ".parse" do
-    it "encodes the string" do
-      expect(subject::Support).to receive(:encode).with(string)
-      allow(subject::Support).to receive(:maybe_parse).and_return(double)
-
-      subject.parse(string)
-    end
-
     it "defers to support parse method" do
       result = double
       expect(subject::Support).to receive(:maybe_parse).with(string).and_return(result)
@@ -47,112 +41,49 @@ describe HippieCSV do
   end
 
   describe ".stream" do
-    let(:path) { double }
+    path = fixture_path(:normal)
+    let(:proc) { Proc.new {} }
 
     it "encodes the string" do
-      expect(subject::Support).to receive(:encode).with(string)
       allow(subject::Support).to receive(:maybe_stream).and_return(double)
 
-      subject.stream(path, string)
+      subject.stream(path, &proc)
     end
 
     it "defers to support stream method" do
       result = double
-      expect(subject::Support).to receive(:maybe_stream).with(path, string).and_return(result)
-
-      expect(subject.stream(path, string)).to eq(result)
+      expect(subject::Support).to receive(:maybe_stream).with(path, &proc).and_return(result)
+      expect(subject.stream(path, &proc)).to eq(result)
     end
 
-    context "when unable to stream" do
-      before do
-        expect(subject::Support).to receive(:maybe_stream).and_return(nil)
-      end
+    it "works" do
+      path = fixture_path(:normal)
 
-      it "raises an error" do
-        expect {
-          subject.stream(path, string)
-        }.to raise_error(
-          subject::UnableToParseError,
-          "Something went wrong. Report this CSV: https://github.com/intercom/hippie_csv"
-        )
-      end
+      result = []
+      subject.stream(path) { |row| result << row }
+      expect(result[0]).to eq(["id", "email", "name", "country", "city", "created_at", "admin"])
     end
   end
 
   context "integration cases: hard/encountered problems" do
-    it "works when a BOM is present in the file" do
-      path = fixture_path(:with_byte_order_mark)
-      expect { CSV.read(path) }.to raise_error(CSV::MalformedCSVError)
 
-      import = subject.read(path)
-      expect(import[0]).to eq(["Name", "Email Address", "Date Added"])
+    def read(path)
+      subject.read(path)
     end
 
-    it "works with a malformed CSV" do
-      path = fixture_path(:malformed)
-      expect { CSV.read(path) }.to raise_error(CSV::MalformedCSVError)
-
-      import = subject.read(path)
-      expect(import[0]).to eq(%w(site lon lat max min precip snow snowdepth))
+    def stream(path)
+      [].tap do |rows|
+        subject.stream(path) do |row|
+          rows << row
+        end
+      end
     end
 
-    it "works with odd encoding & emoji!" do
-      path = fixture_path(:encoding)
-      expect { CSV.read(path) }.to raise_error(ArgumentError)
-
-      import = subject.read(path)
-      expect(import[0].count).to eq(4)
+    def subject_call_method(method, path)
+      send(method, path)
     end
 
-    it "works with an excel export" do
-      path = fixture_path(:excel)
-
-      import = subject.read(path)
-      expect(import[0].count).to eq(24)
-    end
-
-    it "works with unescaped internal quotes" do
-      path = fixture_path(:internal_quotes)
-      expect { CSV.read(path) }.to raise_error(CSV::MalformedCSVError)
-
-      import = subject.read(path)
-      expect(import[1][1]).to eq("123")
-      expect(import[1][2]).to eq("James Jimmy Doe")
-    end
-
-    it "works with escaped quotes" do
-      path = fixture_path(:escaped_quotes)
-
-      import = subject.read(path)
-      expect(import[0][1]).to eq("Lalo \"ElPapi\" Neymar")
-      expect(import[0][2]).to eq("lalo@example.com")
-    end
-
-    it "works with an invalid escaped quotes case" do
-      path = fixture_path(:escaped_quotes_semicolons)
-
-      import = subject.read(path)
-      expect(import[0][0]).to eq("133")
-      expect(import[0][1]).to eq("z3268856")
-      expect(import[0][2]).to eq("stephen@example.com")
-    end
-
-    it "works for a complicated case involving bad newlines and quote chars" do
-      path = fixture_path(:dos_line_ending)
-
-      import = subject.read(path)
-      expect(import[0].count).to eq(9)
-    end
-
-    it "works for a hard case" do
-      path = fixture_path(:accents_semicolon_windows_1252)
-
-      import = subject.read(path)
-      expect(import[0][1]).to eq("Jérome")
-      expect(import[1][0]).to eq("Héloise")
-    end
-
-    it "deals with a long, challenging file (and quickly)" do
+    it "::read deals with a long, challenging file (and quickly)" do
       start_time = Time.now
       path = fixture_path(:never_ordered)
 
@@ -163,31 +94,102 @@ describe HippieCSV do
       expect(Time.now).to be_within(5).of(start_time)
     end
 
-    it "works when many invalid quote types contained" do
-      path = fixture_path(:bad_quoting)
+    %w[read stream].each do |method|
+      it "::#{method} works when a BOM is present in the file" do
+        path = fixture_path(:with_byte_order_mark)
 
-      expect { CSV.read(path) }.to raise_error(CSV::MalformedCSVError)
-      expect {
-        import = subject.read(path)
-        expect(import.map(&:count).uniq).to eq([11])
-        expect(import.count).to eq(8)
-      }.not_to raise_error
-    end
+        import = subject_call_method(method, path)
+        expect(import[0]).to eq(["Name", "Email Address", "Date Added"])
+      end
 
-    it "strips leading/trailing blank lines" do
-      path = fixture_path(:trailing_leading_blank_lines)
+      it "::#{method} works with a malformed CSV" do
+        path = fixture_path(:malformed)
+        expect { CSV.read(path) }.to raise_error(CSV::MalformedCSVError)
 
-      import = subject.read(path)
-      expect(import.first).not_to be_empty
-      expect(import.last).not_to be_empty
-    end
+        import = subject_call_method(method, path)
+        expect(import[0]).to eq(%w(site lon lat max min precip snow snowdepth))
+      end
 
-    it "maintains coherent column count when stripping blank lines" do
-      [:blank_lines_crlf, :trailing_leading_blank_lines].each do |fixture_name|
-        path = fixture_path(fixture_name)
+      it "::#{method} works with odd encoding & emoji!" do
+        path = fixture_path(:encoding)
+        expect { CSV.read(path) }.to raise_error(ArgumentError)
 
-        import = subject.read(path)
-        expect(import.map(&:length).uniq.size).to eq(1)
+        import = subject_call_method(method, path)
+        expect(import[0].count).to eq(4)
+      end
+
+      it "::#{method} works with an excel export" do
+        path = fixture_path(:excel)
+
+        import = subject_call_method(method, path)
+        expect(import[0].count).to eq(24)
+      end
+
+      it "::#{method} works with unescaped internal quotes" do
+        path = fixture_path(:internal_quotes)
+
+        import = subject_call_method(method, path)
+        expect(import[1][1]).to eq("123")
+        expect(import[1][2]).to eq("James Jimmy Doe")
+      end
+
+      it "::#{method} works with escaped quotes" do
+        path = fixture_path(:escaped_quotes)
+
+        import = subject_call_method(method, path)
+        expect(import[0][1]).to eq("Lalo \"ElPapi\" Neymar")
+        expect(import[0][2]).to eq("lalo@example.com")
+      end
+
+      it "::#{method} works with an invalid escaped quotes case" do
+        path = fixture_path(:escaped_quotes_semicolons)
+
+        import = subject_call_method(method, path)
+        expect(import[0][0]).to eq("133")
+        expect(import[0][1]).to eq("z3268856")
+        expect(import[0][2]).to eq("stephen@example.com")
+      end
+
+      it "::#{method} works for a complicated case involving bad newlines and quote chars" do
+        path = fixture_path(:dos_line_ending)
+
+        import = subject_call_method(method, path)
+        expect(import[0].count).to eq(9)
+      end
+
+      it "::#{method} works for a hard case" do
+        path = fixture_path(:accents_semicolon_windows_1252)
+
+        import = subject_call_method(method, path)
+        expect(import[0][1]).to eq("Jérome")
+        expect(import[1][0]).to eq("Héloise")
+      end
+
+      it "::#{method} works when many invalid quote types contained" do
+        path = fixture_path(:bad_quoting)
+
+        expect {
+          import = subject_call_method(method, path)
+          expect(import.map(&:count).uniq).to eq([11])
+          expect(import.count).to eq(8)
+        }.not_to raise_error
+      end
+
+      it "::#{method} strips leading/trailing blank lines" do
+        path = fixture_path(:trailing_leading_blank_lines)
+
+        import = subject_call_method(method, path)
+        expect(import.first).not_to be_empty
+        expect(import.last).not_to be_empty
+      end
+
+      it "::#{method} maintains coherent column count when stripping blank lines" do
+        [:blank_lines_crlf, :trailing_leading_blank_lines].each do |fixture_name|
+          path = fixture_path(fixture_name)
+
+          import = subject_call_method(method, path)
+          expect(import.map(&:length).uniq.size).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
closes https://github.com/intercom/hippie_csv/issues/32

This PR:
1. Adds a missing spec for `.maybe_parse`
2. Updates the readme to include new public method `.stream`
3. Updates `.stream` to require a file path and a block
4. Updates `.maybe_stream` to take a sample of only the first 10 rows, guess the delimiter, and then loop through the csv row at a time to allow faster / more efficient memory-wise processing